### PR TITLE
Fix Install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Contributions or Beer will be appreciated
 
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
-  - [Install](#install)
+  - [Install](#installing)
     - [Dependencies](#dependencies)
     - [Add As Package](#add-as-package)
     - [Add As Reference](#add-as-reference)


### PR DESCRIPTION
The Install link in the menu was redirecting to the "Install" header which actually is named "Installing"